### PR TITLE
Proposed changes to the defer statement

### DIFF
--- a/gb.h
+++ b/gb.h
@@ -612,27 +612,15 @@ extern "C++" {
 //
 #if defined(__cplusplus) && ((defined(_MSC_VER) && _MSC_VER >= 1400) || (__cplusplus >= 201103L))
 extern "C++" {
-	// NOTE(bill): Stupid fucking templates
-	template <typename T> struct gbRemoveReference       { typedef T Type; };
-	template <typename T> struct gbRemoveReference<T &>  { typedef T Type; };
-	template <typename T> struct gbRemoveReference<T &&> { typedef T Type; };
-
-	/// NOTE(bill): "Move" semantics - invented because the C++ committee are idiots (as a collective not as indiviuals (well a least some aren't))
-	template <typename T> inline T &&gb_forward(typename gbRemoveReference<T>::Type &t)  { return static_cast<T &&>(t); }
-	template <typename T> inline T &&gb_forward(typename gbRemoveReference<T>::Type &&t) { return static_cast<T &&>(t); }
-	template <typename T> inline T &&gb_move   (T &&t)                                   { return static_cast<typename gbRemoveReference<T>::Type &&>(t); }
-	template <typename F>
-	struct gbprivDefer {
+	template <typename F> struct gbprivDefer {
 		F f;
-		gbprivDefer(F &&f) : f(gb_forward<F>(f)) {}
 		~gbprivDefer() { f(); }
 	};
-	template <typename F> gbprivDefer<F> gb__defer_func(F &&f) { return gbprivDefer<F>(gb_forward<F>(f)); }
-
+	struct gbprivDeferDummy {};
+	template <typename F> gbprivDefer<F> operator+(gbprivDeferDummy, F f) { return {f}; }
 	#define GB_DEFER_1(x, y) x##y
 	#define GB_DEFER_2(x, y) GB_DEFER_1(x, y)
-	#define GB_DEFER_3(x)    GB_DEFER_2(x, __COUNTER__)
-	#define defer(code)      auto GB_DEFER_3(_defer_) = gb__defer_func([&](){code;})
+	#define defer auto GB_DEFER_2(_defer, __LINE__) = gbprivDeferDummy{} + [&]() -> void
 }
 
 // Example
@@ -641,7 +629,7 @@ extern "C++" {
 	gb_mutex_init(&m);
 	{
 		gb_mutex_lock(&m);
-		defer (gb_mutex_unlock(&m));
+		defer { gb_mutex_unlock(&m); };
 
 		...
 	}


### PR DESCRIPTION
- Shortened implementation by 8 lines (50%)
- Replaced parentheses with braces in defer syntax. This improves readability for multi-line deferred blocks.
- Removed gbRemoveReference, gb_forward, and gb_move; copying is O.K. here since deferred lambdas only hold references.
- Improved portability by replacing __COUNTER__ with __LINE__, because users only write one defer statement per line, and never in the global scope.
  (If users really must write global defers, __COUNTER__ can be put back.)
- Returning values is now explicitly disallowed, as it would not perform the expected behaviour.
