### PR TITLE
Fix gb_mat4_look_at

### DIFF
--- a/gb_math.h
+++ b/gb_math.h
@@ -1732,9 +1732,9 @@ void gb_mat4_look_at(gbMat4 *out, gbVec3 eye, gbVec3 centre, gbVec3 up) {
 	m[1][2] = -f.y;
 	m[2][2] = -f.z;
 
-	m[3][0] = gb_vec3_dot(s, eye);
-	m[3][1] = gb_vec3_dot(u, eye);
-	m[3][2] = gb_vec3_dot(f, eye);
+	m[3][0] = -gb_vec3_dot(s, eye);
+	m[3][1] = -gb_vec3_dot(u, eye);
+	m[3][2] = +gb_vec3_dot(f, eye);
 }
 
 


### PR DESCRIPTION
Changed signs of two dot product vectors at the end of the function. This apparently reflects the implementation in glm. gb_mat4_look_at was projecting coordinates in a very broken and deformed way until i made this change, now it seems to work as intended.

Reference function used:
https://stackoverflow.com/a/19740748/475468