### PR TITLE
Fixing declaration/implementation mismatch

### DIFF
--- a/gb_math.h
+++ b/gb_math.h
@@ -1399,7 +1399,7 @@ gbMat3 *gb_mat3_f(float m[3][3]) { return (gbMat3 *)m; }
 
 gbFloat3 *gb_float33_m(gbMat3 *m)   { return (gbFloat3 *)m; }
 gbFloat3 *gb_float33_v(gbVec3 m[3]) { return (gbFloat3 *)m; }
-gbFloat3 *gb_float33_16(float m[9]) { return (gbFloat3 *)m; }
+gbFloat3 *gb_float33_9(float m[9]) { return (gbFloat3 *)m; }
 
 void gb_float33_transpose(float (*vec)[3]) {
 	int i, j;


### PR DESCRIPTION
I'm not entirely sure whether the declaration is wrong or the implementation, so if I got this backwards, apologies. But, there is presently no implementation of `gb_float33_9` and no declaration of `gb_float33_16`, so I assumed one was supposed to match the other. (I'm not actually using this function, but discovered the missing part when doing some automatic Lua bindings based on importing headers.)