### PR TITLE
docs: fix simple typo, systen -> system

### DIFF
--- a/gb_gl.h
+++ b/gb_gl.h
@@ -39,7 +39,7 @@
 
 	Steps for supporting dynamic reload:
 		You _MUST_ defined you own malloc and free that use whatever
-		permanent memory systen you are using:
+		permanent memory system you are using:
 
 			#define gbgl_malloc
 			#define gbgl_free


### PR DESCRIPTION
There is a small typo in gb_gl.h.

Should read `system` rather than `systen`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md